### PR TITLE
Allow bootlogd to "self-start"

### DIFF
--- a/man/bootlogd.8
+++ b/man/bootlogd.8
@@ -26,6 +26,7 @@ bootlogd \- record boot messages
 .RB [ \-v ]
 .RB [ " -l logfile " ]
 .RB [ \-p ]
+.RB [ " -f command " ]
 .SH DESCRIPTION
 \fBBootlogd\fP runs in the background and copies all strings sent to the
 \fI/dev/console\fP device to a logfile. If the logfile is not accessible,
@@ -53,6 +54,8 @@ Log to this logfile. The default is \fI/run/log/stage-1.log\fP.
 .IP \fB\-p\fP
 Prepares the minimum required environment.
 /dev and /dev/pts will be mounted.
+.IP "\fB\-f\fP \fIcommand\fP"
+Forks bootlogd as a child process, and `execve` into command.
 .SH NOTES
 bootlogd saves log data which includes control characters. The log is
 technically a text file, but not very easy for humans to read. To address

--- a/man/bootlogd.8
+++ b/man/bootlogd.8
@@ -25,6 +25,7 @@ bootlogd \- record boot messages
 .RB [ \-s ]
 .RB [ \-v ]
 .RB [ " -l logfile " ]
+.RB [ \-p ]
 .SH DESCRIPTION
 \fBBootlogd\fP runs in the background and copies all strings sent to the
 \fI/dev/console\fP device to a logfile. If the logfile is not accessible,
@@ -49,6 +50,9 @@ process running in parallel.
 Show version.
 .IP "\fB\-l\fP \fIlogfile\fP"
 Log to this logfile. The default is \fI/run/log/stage-1.log\fP.
+.IP \fB\-p\fP
+Prepares the minimum required environment.
+/dev and /dev/pts will be mounted.
 .SH NOTES
 bootlogd saves log data which includes control characters. The log is
 technically a text file, but not very easy for humans to read. To address

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,6 +8,10 @@
 # Version:	@(#)Makefile  2.85-13  23-Mar-2004  miquels@cistron.nl
 #
 
+# Version from sysvinit this was based on, 2.95.
+# And an additional monotonically increasing number.
+VERSION = "2.95.1"
+
 CPPFLAGS =
 CFLAGS  ?= -O2 -Werror
 override CFLAGS += -ansi -fomit-frame-pointer -fstack-protector-strong -W -Wall -Wunreachable-code -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -D_XOPEN_SOURCE -D_GNU_SOURCE -DVERSION=\"$(VERSION)\"

--- a/src/bootlogd.c
+++ b/src/bootlogd.c
@@ -476,6 +476,15 @@ int main(int argc, char **argv)
 		usage();
 	}
 
+	/*
+	 * When started as `/init`, we assume
+	 * bootlogd -p -f /init.2nd
+	 */
+	if (strcmp(argv[0], "/init") == 0) {
+		prepare_env = 1;
+		exec_into = "/init.2nd";
+	}
+
 	if (prepare_env) {
 		/* Mount /dev */
 		ret = mkdir("/dev", 0755);


### PR DESCRIPTION
Fixes #2 and fixes #3.

First, `bootlogd` can setup the environment as it requires. It will `mkdir` and `mount` accordingly.

Then, this adds the "fork and exec" strategy, which allows `bootlogd` to run something else once ready.

Finally, when ran as `/init`, it will implicitly setup the environment, and use the "fork and exec" strategy with `init.2nd`.